### PR TITLE
Remove Rx Java (it's not used)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,9 +46,6 @@ dependencies {
     implementation 'android.arch.paging:runtime:1.0.0'
     implementation 'android.arch.lifecycle:extensions:1.1.1'
 
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.9'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
-
     implementation 'com.an.customfontview:customfont:0.1.0'
 
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'


### PR DESCRIPTION
I read the article wondering why callbacks where used when rxjava was included